### PR TITLE
Closes #10

### DIFF
--- a/Baseball-Itinerary-Program/primewin.h
+++ b/Baseball-Itinerary-Program/primewin.h
@@ -53,6 +53,9 @@ public:
     //Validates phone numbers and returns a formatted number
     QString phoneCheck(QString phone);
 
+    //Calculates the itinerary's trip distance
+    void calcTrip();
+
 public slots:
     void catchLoginStatus(bool status); //Catches login signal
 


### PR DESCRIPTION
Queueing and dequeing stadiums from the itinerary will recalculate the trip distance now.

Changelog:
- **Added** PrimeWin::calcTrip() which iterates through the itinerary, calculates the distance bewteen each stadium, adds them all together, then updates the itinerary distance label.
- Added calcTrip() function call to PrimeWin::catchAddItin()
	- This calls PrimeWin::calcTrip() everytime a stadium is queued or dequeued from the itinerary
- Removed some old comments
- Made a couple of things a little neater